### PR TITLE
Fixed reminder frequency check on reminder update

### DIFF
--- a/CSSBot/Reminders/ReminderService.cs
+++ b/CSSBot/Reminders/ReminderService.cs
@@ -79,10 +79,11 @@ namespace CSSBot.Reminders
                     if (option.HasValue)
                         reminder.ReminderTimeOption = option.Value;
 
+                    // check which of our ReminderTimeOption flags we set have already passed
+                    CheckReminderTimeOption(ref reminder);
 
-                    // save and poll once again
+                    // save it afterwards
                     SaveReminders();
-                    CheckReminderState();
                 }
             }
         }


### PR DESCRIPTION
Previously was creating several alerts each time a reminder's frequency was updated. This checks each of the reminder values when its updated. This means it won't spam with reminders once the reminders are updated, I'm assuming that the user is going to check on it later on.