### PR TITLE
Retry command execution when the original message gets updated

### DIFF
--- a/CSSBot.Tests/CSSBot.Tests.csproj
+++ b/CSSBot.Tests/CSSBot.Tests.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Discord.Net" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0-preview-20180924-03" />
-    <PackageReference Include="xunit" Version="2.4.1-pre.build.4059" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1-pre.build.4059">
+    <PackageReference Include="Discord.Net" Version="2.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0-preview-20190203-03" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/CSSBot/CSSBot.csproj
+++ b/CSSBot/CSSBot.csproj
@@ -4,10 +4,10 @@
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Discord.Net" Version="2.0.0" />
-    <PackageReference Include="Humanizer" Version="2.5.1" />
+    <PackageReference Include="Discord.Net" Version="2.0.1" />
+    <PackageReference Include="Humanizer" Version="2.5.16" />
     <PackageReference Include="LiteDB" Version="4.1.4" />
-    <PackageReference Include="System.Net.Http" Version="4.3.3" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
     <PackageReference Include="System.Xml.XDocument" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />

--- a/CSSBot/Commands/BasicCommands.cs
+++ b/CSSBot/Commands/BasicCommands.cs
@@ -1,4 +1,5 @@
-﻿using Discord;
+﻿using CSSBot.Services;
+using Discord;
 using Discord.Commands;
 using Discord.WebSocket;
 using System;
@@ -16,14 +17,14 @@ namespace CSSBot.Commands
     /// use an empty name attribute because these are default
     /// </summary>
     [Name("")]
-    public class BasicCommands : ModuleBase
+    public class BasicCommands : RetryModuleBase
     {
         // as far as I'm concerned, Dependency Injection is black magic
         // here are the docs I referenced to get this working
         // https://discord.foxbot.me/docs/guides/commands/commands.html#dependency-injection
         private readonly CommandService _commandService;
 
-        public BasicCommands(CommandService commands)
+        public BasicCommands(CommandService commands, MessageRetryService retryService) : base(retryService)
         {
             _commandService = commands;
         }
@@ -35,7 +36,7 @@ namespace CSSBot.Commands
         [Command("Ping"), Summary("A simple ping/pong command, for checking if the bot works.")]
         public async Task Ping()
         {
-            await ReplyAsync("Pong!");
+            await ReplyOrUpdateAsync("Pong!");
         }
 
         private const char ZeroWidthSpace = '\x200b';
@@ -49,7 +50,7 @@ namespace CSSBot.Commands
         [Command("Echo"), Summary("A simple echo command.")]
         public async Task Echo([Name("Text"), Summary("The text to echo back."), Remainder] string text)
         {
-            await ReplyAsync(Context.User.Mention + " : " + SanitizeMentions(text));
+            await ReplyOrUpdateAsync(Context.User.Mention + " : " + SanitizeMentions(text));
         }
 
         /// <summary>
@@ -62,7 +63,7 @@ namespace CSSBot.Commands
         public async Task About()
         {
             string txt = string.Format("🤔 CSSBot 🤔\nGitHub: https://github.com/Chris-Johnston/CSSBot");
-            await ReplyAsync(txt);
+            await ReplyOrUpdateAsync(txt);
         }
 
         [Command("Cleanup", RunMode = RunMode.Async)]
@@ -90,7 +91,7 @@ namespace CSSBot.Commands
         [RequireUserPermission(GuildPermission.SendMessages | GuildPermission.EmbedLinks)]
         public async Task InviteLink()
         {
-            await ReplyAsync($"A user with the 'Manage Server' permission can add me to your server using the following link: https://discordapp.com/oauth2/authorize?client_id={Context.Client.CurrentUser.Id}&scope=bot");
+            await ReplyOrUpdateAsync($"A user with the 'Manage Server' permission can add me to your server using the following link: https://discordapp.com/oauth2/authorize?client_id={Context.Client.CurrentUser.Id}&scope=bot");
         }
 
         [Command("Debug")]
@@ -98,7 +99,7 @@ namespace CSSBot.Commands
         [RequireUserPermission(GuildPermission.SendMessages)]
         public async Task DebugInfo()
         {
-            await ReplyAsync(
+            await ReplyOrUpdateAsync(
                 $"{Format.Bold("Info")}\n" +
                 $"- D.NET Lib Version {DiscordConfig.Version} (API v{DiscordConfig.APIVersion})\n" +
                 $"- Runtime: {RuntimeInformation.FrameworkDescription} {RuntimeInformation.OSArchitecture}\n" +

--- a/CSSBot/Commands/RetryExampleCommand.cs
+++ b/CSSBot/Commands/RetryExampleCommand.cs
@@ -1,0 +1,21 @@
+﻿using CSSBot.Services;
+using Discord.Commands;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CSSBot.Commands
+{
+    public class RetryExampleCommand : RetryModuleBase
+    {
+        public RetryExampleCommand(MessageRetryService retry) : base(retry)
+        { }
+
+        [Command("Test")]
+        public async Task TestRetry(int a, int b)
+        {
+            await ReplyOrUpdateAsync($"{a + b}");
+        }
+    }
+}

--- a/CSSBot/Commands/RetryModuleBase.cs
+++ b/CSSBot/Commands/RetryModuleBase.cs
@@ -1,0 +1,52 @@
+﻿using CSSBot.Services;
+using Discord;
+using Discord.Commands;
+using Discord.WebSocket;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CSSBot.Commands
+{
+    public class RetryModuleBase : ModuleBase
+    {
+        public MessageRetryService messageRetry;
+
+        public RetryModuleBase(MessageRetryService messageRetry)
+        {
+            this.messageRetry = messageRetry;
+        }
+
+        /// <summary>
+        ///     Replies to the original message, or updates if there was an edit.
+        ///     Does not work with commands with multiple message responses.
+        /// </summary>
+        /// <param name="message"></param>
+        internal async Task ReplyOrUpdateAsync(string message = null, bool isTTS = false, Embed embed = null)
+        {
+            var id = messageRetry.GetMessageToUpdate(Context);
+            if (id.HasValue)
+            {
+                // id already exists
+                var m = await Context.Channel.GetMessageAsync(id.Value);
+                if (m is IUserMessage usermessage)
+                {
+                    // update the existing message
+                    await usermessage.ModifyAsync(x =>
+                    {
+                        x.Content = message;
+                        x.Embed = embed;
+                    });
+                    // don't need to update message IDs
+                }
+            }
+            else
+            {
+                // id doesn't already exist, so create a new message
+                var msg = await ReplyAsync(message, isTTS, embed);
+                messageRetry.RegisterSuccessfulCommand(Context.Message.Id, msg.Id);
+            }
+        }
+    }
+}

--- a/CSSBot/Properties/launchSettings.json
+++ b/CSSBot/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "CSSBot": {
       "commandName": "Project",
-      "commandLineArgs": "-config=C:\\Discord\\testconfig.xml"
+      "commandLineArgs": "-config=D:\\DiscordDebugBot\\Config.xml"
     }
   }
 }

--- a/CSSBot/Services/MessageRetryService.cs
+++ b/CSSBot/Services/MessageRetryService.cs
@@ -1,0 +1,102 @@
+﻿using Discord.Commands;
+using Discord.Net;
+using Discord.WebSocket;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CSSBot.Services
+{
+    public class MessageRetryService
+    {
+        public const int MessageLimit = 1000;
+
+        private readonly DiscordSocketClient client;
+        /// <summary>
+        ///     Stores the resulting message from a single command invocation as the value, keyed by the message ID that originally started it.
+        /// </summary>
+        private Dictionary<ulong, ulong> CommandMessageResults = new Dictionary<ulong, ulong>();
+        /// <summary>
+        ///     Stores successful messages, max of LIMIT.
+        ///     Should be the same length as CommandMessageResults
+        /// </summary>
+        private Queue<ulong> SuccessfulMessages = new Queue<ulong>(MessageLimit);
+
+        public ulong? GetMessageToUpdate(ICommandContext context)
+        {
+            if (CommandMessageResults.ContainsKey(context.Message.Id))
+            {
+                return CommandMessageResults[context.Message.Id];
+            }
+            return null;
+        }
+
+        /// <summary>
+        ///     Command handler that is called when this edited message should be retried.
+        /// </summary>
+        public event Func<SocketMessage, Task>  OnCommandRetryHandler;
+
+        public MessageRetryService(DiscordSocketClient client)
+        {
+            this.client = client;
+            SetupHandlers();
+        }
+
+        public void RegisterSuccessfulCommand(ulong messageId, ulong newMessage)
+        {
+            Console.WriteLine($"Registering {messageId} -> {newMessage}");
+            // only register if not already contained in the queue
+            if (!CommandMessageResults.ContainsKey(messageId))
+            {
+                // regiser that this command was successful
+                SuccessfulMessages.Enqueue(messageId);
+                CommandMessageResults.Add(messageId, newMessage);
+
+                // stop tracking old messages
+                while (SuccessfulMessages.Count > MessageLimit)
+                {
+                    var removed = SuccessfulMessages.Dequeue();
+                    Console.WriteLine($"removed old id {removed}");
+                    if (CommandMessageResults.ContainsKey(removed))
+                    {
+                        CommandMessageResults.Remove(removed);
+                    }
+                }
+            }
+        }
+
+        private void SetupHandlers()
+        {
+            client.MessageUpdated += Client_MessageUpdated;
+            client.MessageDeleted += Client_MessageDeleted;
+        }
+
+        private async Task Client_MessageDeleted(Discord.Cacheable<Discord.IMessage, ulong> arg1, ISocketMessageChannel arg2)
+        {
+            // if the original message was successful and is deleted, delete the related messages
+            if (CommandMessageResults.ContainsKey(arg1.Id))
+            {
+                var messageId = CommandMessageResults[arg1.Id];
+                
+                try
+                {
+                    // delete the result of the original command message
+                    await arg2.DeleteMessageAsync(messageId);
+                }
+                catch (HttpException)
+                { }
+            }
+        }
+
+        private async Task Client_MessageUpdated(Discord.Cacheable<Discord.IMessage, ulong> before, SocketMessage after, ISocketMessageChannel channel)
+        {
+            if (CommandMessageResults.ContainsKey(after.Id))
+            {
+                // todo consider making the limit on update time-limited as well
+                // re-invoke the command handler. this assumes that the command module is using ReplyOrUpdateAsync
+                await OnCommandRetryHandler?.Invoke(after);
+            }
+        }
+    }
+}

--- a/CSSBot/Services/MessageRetryService.cs
+++ b/CSSBot/Services/MessageRetryService.cs
@@ -57,7 +57,7 @@ namespace CSSBot.Services
                 while (SuccessfulMessages.Count > MessageLimit)
                 {
                     var removed = SuccessfulMessages.Dequeue();
-                    Console.WriteLine($"removed old id {removed}");
+                    Console.WriteLine($"Removed old message Id {removed}");
                     if (CommandMessageResults.ContainsKey(removed))
                     {
                         CommandMessageResults.Remove(removed);

--- a/CSSBot/Services/Reminders/Commands/ReminderCommands.cs
+++ b/CSSBot/Services/Reminders/Commands/ReminderCommands.cs
@@ -13,7 +13,7 @@ using Humanizer;
 namespace CSSBot
 {
     [Group("Reminder"), Alias("R")]
-    public class ReminderCommands : ModuleBase
+    public class ReminderCommands : ModuleBase // don't use ReplyModuleBase, since that may result in a lot of accidental timers
     {
         private readonly ReminderService _reminderService;
 


### PR DESCRIPTION
This adds a `RetryModuleBase` type which tracks up to 1000 previous messages and the bot's responses to those messages. When a user edits the original message, the bot will re-evaluate the command and edit the original response instead of sending a new message.

