### PR TITLE
fix #28 add precondition to datetime in reminders

### DIFF
--- a/CSSBot/Services/Reminders/Commands/NotExpiredPrecondition.cs
+++ b/CSSBot/Services/Reminders/Commands/NotExpiredPrecondition.cs
@@ -15,7 +15,7 @@ namespace CSSBot
         }
         public NotExpiredPreconditionAttribute(DateTime date)
         {
-            now = date ?? DateTime.Now;
+            now = date;
         }
 
         public override async Task<PreconditionResult> CheckPermissionsAsync(ICommandContext context, ParameterInfo parameter, object value, IServiceProvider services)

--- a/CSSBot/Services/Reminders/Commands/NotExpiredPrecondition.cs
+++ b/CSSBot/Services/Reminders/Commands/NotExpiredPrecondition.cs
@@ -1,0 +1,30 @@
+﻿using Discord.Commands;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CSSBot
+{
+    public class NotExpiredPreconditionAttribute : ParameterPreconditionAttribute
+    {
+        private DateTime now;
+        public NotExpiredPreconditionAttribute()
+        {
+            now = DateTime.Now;
+        }
+        public NotExpiredPreconditionAttribute(DateTime date)
+        {
+            now = date ?? DateTime.Now;
+        }
+
+        public override async Task<PreconditionResult> CheckPermissionsAsync(ICommandContext context, ParameterInfo parameter, object value, IServiceProvider services)
+        {
+            if (value is DateTime time)
+            {
+                return now.CompareTo(time) >= 0 ? PreconditionResult.FromSuccess() : PreconditionResult.FromError("The provided time was after the current time.");
+            }
+            return PreconditionResult.FromError("The type of value was not a DateTime.");
+        }
+    }
+}

--- a/CSSBot/Services/Reminders/Commands/ReminderCommands.cs
+++ b/CSSBot/Services/Reminders/Commands/ReminderCommands.cs
@@ -29,7 +29,7 @@ namespace CSSBot
         [Command("Add", RunMode = RunMode.Async)]
         [Alias("Create", "+", "New", "AddReminder", "CreateReminder", "NewReminder")]
         [RequireContext(ContextType.Guild)]
-        public async Task AddReminder([Name("Time")]DateTime reminderTime, [Name("Reminder"), Remainder()]string ReminderText)
+        public async Task AddReminder([Name("Time"), NotExpiredPrecondition]DateTime reminderTime, [Name("Reminder"), Remainder()]string ReminderText)
         {
             var added = _reminderService.AddReminder(Context.Guild.Id, Context.Channel.Id, Context.User.Id,
                 ReminderText, reminderTime);
@@ -43,7 +43,7 @@ namespace CSSBot
         [Alias("CreateChannel", "+Channel")]
         [RequireContext(ContextType.Guild)]
         [RequireUserPermission(GuildPermission.ManageMessages)]
-        public async Task AddChannelReminder([Name("Time")]DateTime reminderTime, [Name("Reminder"), Remainder()]string ReminderText)
+        public async Task AddChannelReminder([Name("Time"), NotExpiredPrecondition]DateTime reminderTime, [Name("Reminder"), Remainder()]string ReminderText)
         {
             var added = _reminderService.AddReminder(Context.Guild.Id, Context.Channel.Id, Context.User.Id,
                 ReminderText, reminderTime, ReminderType.Channel);
@@ -56,7 +56,7 @@ namespace CSSBot
         [Alias("CreateServer", "+Server", "AddGuild", "CreateGuild", "+Guild")]
         [RequireContext(ContextType.Guild)]
         [RequireUserPermission(ChannelPermission.ManageMessages)]
-        public async Task AddGuildReminder([Name("Time")]DateTime reminderTime, [Name("Reminder"), Remainder()]string ReminderText)
+        public async Task AddGuildReminder([Name("Time"), NotExpiredPrecondition]DateTime reminderTime, [Name("Reminder"), Remainder()]string ReminderText)
         {
             var added = _reminderService.AddReminder(Context.Guild.Id, Context.Channel.Id, Context.User.Id,
                 ReminderText, reminderTime, ReminderType.Guild);


### PR DESCRIPTION
fix #28 

prevent users from creating reminders that are already expired with a precondition that checks the datetime parameter of the reminder commands